### PR TITLE
Add math tests for Wilson scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Board Game Rank
 
-This project ranks board games using a weighted Wilson lower bound with a strict 99.5\% confidence. Each game is adjusted with 25 prior votes at rating 6.5 to reduce small-sample effects. The script reads a CSV export from BoardGameGeek and produces a sortable HTML table.
+This project ranks board games using a weighted Wilson lower bound with a strict 99.5% one-sided confidence (z≈2.576). Each game is adjusted with 25 prior votes at rating 6.5 to reduce small-sample effects. The script reads a CSV export from BoardGameGeek and produces a sortable HTML table.
 
 ## Generate the page
 

--- a/generate_page.py
+++ b/generate_page.py
@@ -2,8 +2,10 @@ import csv
 from math import sqrt
 from typing import Union, Tuple
 
+DEFAULT_Z = 2.576  # z-score for 99.5% one-sided Wilson interval
 
-def wilson_lower_bound_10pt(n: int, S: Union[int, float], z: float = 2.576) -> float:
+
+def wilson_lower_bound_10pt(n: int, S: Union[int, float], z: float = DEFAULT_Z) -> float:
     if n <= 0:
         return 0.0
     R = S / n

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,46 @@
+import csv
+import math
+from pathlib import Path
+from scipy.stats import norm
+import pytest
+
+import generate_page as gp
+
+
+def test_wilson_manual_example():
+    n, S = 100, 800
+    z = norm.ppf(0.995)  # 99.5% one-sided
+    R = S / n
+    p = (R - 1) / 9.0
+    denom = 1 + z * z / n
+    centre = p + z * z / (2 * n)
+    adj = z * math.sqrt((p * (1 - p) + z * z / (4 * n)) / n)
+    expected = 1 + 9 * (centre - adj) / denom
+    assert gp.wilson_lower_bound_10pt(n, S, z) == pytest.approx(expected)
+
+
+def test_wilson_zero_votes():
+    assert gp.wilson_lower_bound_10pt(0, 0) == 0.0
+
+
+def test_weighted_score_matches_manual():
+    csv_path = Path('2025-06-18T11-00-01.csv')
+    with csv_path.open(newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        row = next(reader)  # first game in file
+    n = int(row['Users rated'])
+    avg = float(row['Average'])
+    S = n * avg
+    z = gp.DEFAULT_Z
+    expected = gp.wilson_lower_bound_10pt(
+        n + gp.PRIOR_VOTES,
+        S + gp.PRIOR_VOTES * gp.PRIOR_RATING,
+        z,
+    )
+    assert gp.weighted_score(n, S) == pytest.approx(expected)
+
+
+def test_status_labels():
+    assert gp.status_for_rank(10) == ("🔥", "Bestseller")
+    assert gp.status_for_rank(500) == ("🔎", "Rare find")
+    assert gp.status_for_rank(2000) == ("💎", "Hidden gem")


### PR DESCRIPTION
## Summary
- document Wilson lower bound constant in README
- expose the 99.5% z-score as DEFAULT_Z
- add unit tests verifying Wilson bound, weighted score and rank labels

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e45a779c8328b596dc109dbffd09